### PR TITLE
Beta>Master (version 0.96.17 ---> version 0.96.18)

### DIFF
--- a/bbk_chprobe
+++ b/bbk_chprobe
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Version 2.37.2 (BBK backoff) 
+# Version 2.39.3 (BBK backoffv2) 
 
 # Dont touch this
 zone=x
@@ -33,7 +33,7 @@ bbk_remotestatus="$(curl --retry 2 -m 3 -s -XGET $bbk_remoteurl)"
  }
 
 # In case two or more tests are executed exactly at the same time, create some random delay
-# We only check abscence of bbk daemons, since the iperf3 server will take care of some collisions. It's a different story if more than one server is used in the same zone, this scenario currently not supported
+# We only check abscence of bbk daemons, since the iperf3 server will take care of some collisions. It's a different story if more than one server is used in the same zone, this scenario is currently not supported
 multiple_bbk () {
 if [ $(pgrep -f 'bbk' | wc -l) -ge 3 ] || [ $multivar -eq 1 ]; then        
 	if [ $ip_version = "4" ]; then
@@ -60,13 +60,9 @@ fi
  }
 
 remotelocal_loop () {
-#if [ $zone != "x" ]; then
-#sleep $probetimer && reinit_status
-#else
-reinit_status
-#fi
+reinit_status; multiple_bbk
 while [ $bbk_remotestatus -eq 1 ] || [ $localstatus -ge 1 ]
-do reinit_status; echo "[$logtag] sleeping 3-$probetimer sec, reason: [remote: $bbk_remotestatus (zone=$zone). local: $localstatus"] | logger -p notice && sleep $[ ( $RANDOM % $probetimer ) + 3]s; multiple_bbk; reinit_status
+do reinit_status; echo "[$logtag] sleeping 3-$probetimer sec, reason: [remote: $bbk_remotestatus (zone=$zone). local: $localstatus multivar: $multivar]" | logger -p notice && sleep $[ ( $RANDOM % $probetimer ) + 3]s; multiple_bbk; reinit_status
 done
  }
 
@@ -124,7 +120,7 @@ if [ $urlcheck -ne 200 ]; then probetimer="$(cat /var/prober_timer.txt)"
 fi
 
 # Sleep for a unique time and then reintroduce urls
-remotelocal_loop; sleep $probetimer; remotelocal_loop
+remotelocal_loop
 fi
 
 # Check if global zone is disabled
@@ -153,10 +149,17 @@ if [ $bbk_remotestatus -eq 1 ] || [ $localstatus -ge 1 ]; then
 					fi
 fi
 
+unique_sleep () {
+if [ $zone != "x" ];then 
+sleep $(expr $probetimer \* $probetimer / 2 + $probetimer + $probetimer);remotelocal_loop
+else remotelocal_loop
+fi
+}
+
 # Allocate the zone and start the desired test
         case "$ip_version" in
                 4)
-remotelocal_loop
+unique_sleep
 setzone 1; echo "[$logtag] Starting bbk_cli [debug: $localstatus | $(pgrep -f 'bbk_cli|tcp_iperf3|iperf3tcp' | wc -l)]" | logger -p notice &&
 bbk_cli --live --quiet | sed -e "s/^/$(date "+%b %d %H:%M:%S") $(hostname -d) $logtag: /" >>/var/log/chprobe_bbk.log &&
 
@@ -164,7 +167,7 @@ bbk_cli --live --quiet | sed -e "s/^/$(date "+%b %d %H:%M:%S") $(hostname -d) $l
 setzone 0; echo "[$logtag] Finished bbk_cli [debug: $localstatus | $(pgrep -f 'bbk_cli|tcp_iperf3|iperf3tcp' | wc -l)]" | logger -p notice
 ;;
 		6)
-remotelocal_loop
+unique_sleep
 setzone 1; echo "[$logtag_ipv6] Starting bbk_cli [debug: $localstatus | $(pgrep -f 'bbk_cli|tcp_iperf3|iperf3tcp' | wc -l)]" | logger -p notice &&
 bbk_cli --live --quiet --v6 | sed -e "s/^/$(date "+%b %d %H:%M:%S") $(hostname -d) $logtag_ipv6: /" >>/var/log/chprobe_bbk.log &&
 

--- a/fw-rules
+++ b/fw-rules
@@ -19,7 +19,7 @@ iptables -A INPUT -s 83.255.225.1/24 -p tcp --dport 34521 -j ACCEPT
 iptables -A INPUT -s 83.248.145.173/32 -p tcp --dport 34521 -j ACCEPT
 iptables -A INPUT -s 83.255.229.1/24 -j ACCEPT
 iptables -A INPUT -s 94.137.97.98/32 -p tcp --dport 34521 -j ACCEPT
-iptables -A INPUT -s $(cat /var/ip_udp.txt) -p tcp --dport 34521 -j ACCEPT
+iptables -A INPUT -s $(cat /var/ip-udp.txt) -p tcp --dport 34521 -j ACCEPT
 
 # Allow SSH from local subnets
 iptables -A INPUT -s 192.168.0.1/24 -p tcp --dport 34521 -j ACCEPT

--- a/icmp_chprobe
+++ b/icmp_chprobe
@@ -29,7 +29,7 @@ done
 backoff=0
 while [ `pgrep -f 'bbk_cli|tcp_iperf3|iperf3tcp' | wc -w` -ge 1 ];do sleep 1 && 
 backoff=$(( $backoff + 1 ))
-if [ $backoff -ge 180 ]; then
+if [ $backoff -ge 240 ]; then
 echo "$logfacility We broke out of the loop because we waited ($backoff). This could be bad" | logger -p local5.err && break
 fi
 done

--- a/multi_chprobe
+++ b/multi_chprobe
@@ -12,7 +12,7 @@ while [ `pgrep -f 'bbk_cli|iperf3|wrk' | wc -w` -ge 30 ];do kill $(pgrep -f "ipe
 backoff=0
 while [ `pgrep -f 'bbk_cli|tcp_iperf3|iperf3tcp' | wc -w` -ge 1 ];do sleep 1 &&
 backoff=$(( $backoff + 1 ))
-if [ $backoff -ge 180 ]; then
+if [ $backoff -ge 240 ]; then
 break && echo "$logfacility We broke out of the loop because we waited $backoff. This could be bad" | logger -p local5.err
 fi
 done

--- a/probe_settings
+++ b/probe_settings
@@ -1,6 +1,22 @@
 #!/bin/bash
-# Version 2.0
+# Version 2.1
 probedir=/home/chprobe
+
+# Run with argument "-s" to enabled strict mode
+# When enabled, all multi tests and icmp tests are disabled during high performance tests (every 15th/16th minute)
+# This will obviously not give the desired effect if you modified the default schedule for iperf3/bbk
+        case "$1" in
+        -s) strict_mode=true ;;
+        -h)  cat <<USAGE
+usage: $0 [-s] [-h]
+
+    -h) See this help
+    -s) Enable strict mode
+USAGE
+            exit 0
+            ;;
+        *) strict_mode=false # Default setting
+    esac
 
 # Check IPv6 connectivity
 echo "Checking IPv6 connectivity, stay tuned..." &&
@@ -56,6 +72,69 @@ echo "*/2  *  *  *  * root /home/chprobe/./icmp_chprobe -v6 100 1 54 ping.sunet.
 */16 *  *  *  * root /home/chprobe/./bbk_chprobe -6 -g &> /dev/null
 */2 * * * * root /home/chprobe/./multi_chprobe -d 2a04:ae3a:ae3a::1 sunet.se 6 &> /dev/null
 */2 * * * * root /home/chprobe/./multi_chprobe -e www.facebook.com 6 &> /dev/null" >> /etc/crontab
+fi
+
+# crontab IPv4 + strict scheduling
+if [ $strict_mode = "true" ]; then
+echo "SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name  command to be executed
+*/6  *  *  *  * root /home/chprobe/./udp_iperf3_client_merged.sh -us &> /dev/null
+*/5  *  *  *  * root /home/chprobe/./udp_iperf3_client_merged.sh -ds &> /dev/null
+*/16 *  *  *  * root /home/chprobe/./tcp_iperf3_clientv3.sh -g -u -4 &> /dev/null
+*/15 *  *  *  * root /home/chprobe/./tcp_iperf3_clientv3.sh -g -d -4 &> /dev/null
+*/30 *  *  *  * root /home/chprobe/./upnpc-probe.sh > /dev/null
+*/30 *  *  *  * root /home/chprobe/./probemanager managerupdate &> /dev/null
+*/60 *  *  *  * root /home/chprobe/./probemanager update &> /dev/null
+5 7  *  *  7    root tar cvfz /root/backups/chprobe_backup-\$(date +\"%d%m%y\"-\"%H%M\" | tr -d '-').tgz /home/chprobe &> /dev/null
+*/20 *  *  *  * root /home/chprobe/./smokeslave_fakepost > /dev/null
+*/15 *  *  *  * root /home/chprobe/./bbk_chprobe -4 -g &> /dev/null
+*/12 * * * * root /home/chprobe/./multi_chprobe -w 3 200 30 http://google.se &> /dev/null
+2-12/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 1 54 ping.sunet.se &> /dev/null
+18-28/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 1 54 ping.sunet.se &> /dev/null
+32-58/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 1 54 ping.sunet.se &> /dev/null
+2-12/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 1 1800 sunet.se &> /dev/null
+18-28/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 1 1800 sunet.se &> /dev/null
+32-58/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 1 1800 sunet.se &> /dev/null
+2-12/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 0.5 54 ping.sunet.se &> /dev/null
+18-28/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 0.5 54 ping.sunet.se &> /dev/null
+32-58/2 * * * * root /home/chprobe/./icmp_chprobe -v4 100 0.5 54 ping.sunet.se &> /dev/null
+2-12/2 * * * * root /home/chprobe/./multi_chprobe -d 83.255.255.2 sunet.se 4 &> /dev/null
+18-28/2 * * * * root /home/chprobe/./multi_chprobe -d 83.255.255.2 sunet.se 4 &> /dev/null
+32-58/2 * * * * root /home/chprobe/./multi_chprobe -d 83.255.255.2 sunet.se 4 &> /dev/null
+2-12/2 * * * * root /home/chprobe/./multi_chprobe -e www.facebook.com 4 &> /dev/null
+18-28/2 * * * * root /home/chprobe/./multi_chprobe -e www.facebook.com 4 &> /dev/null
+32-58/2 * * * * root /home/chprobe/./multi_chprobe -e www.facebook.com 4 &> /dev/null" > /etc/crontab
+
+        if [ $ipmode = "dualstack" ]; then
+echo "*/16 *  *  *  * root /home/chprobe/./bbk_chprobe -6 -g &> /dev/null
+2-12/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 1 54 ping.sunet.se &> /dev/null
+18-28/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 1 54 ping.sunet.se &> /dev/null
+32-58/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 1 54 ping.sunet.se &> /dev/null
+2-12/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 1 1800 sunet.se &> /dev/null
+18-28/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 1 1800 sunet.se &> /dev/null
+32-58/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 1 1800 sunet.se &> /dev/null
+2-12/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 0.5 54 ping.sunet.se &> /dev/null
+18-28/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 0.5 54 ping.sunet.se &> /dev/null
+32-58/2 * * * * root /home/chprobe/./icmp_chprobe -v6 100 0.5 54 ping.sunet.se &> /dev/null
+2-12/2 * * * * root /home/chprobe/./multi_chprobe -e www.facebook.com 6 &> /dev/null
+18-28/2 * * * * root /home/chprobe/./multi_chprobe -e www.facebook.com 6 &> /dev/null
+32-58/2 * * * * root /home/chprobe/./multi_chprobe -e www.facebook.com 6 &> /dev/null
+2-12/2 * * * * root /home/chprobe/./multi_chprobe -d 2a04:ae3a:ae3a::1 sunet.se 6 &> /dev/null
+18-28/2 * * * * root /home/chprobe/./multi_chprobe -d 2a04:ae3a:ae3a::1 sunet.se 6 &> /dev/null
+32-58/2 * * * * root /home/chprobe/./multi_chprobe -d 2a04:ae3a:ae3a::1 sunet.se 6 &> /dev/null" >> /etc/crontab
+        fi
 fi
 
 # rc.local

--- a/probemanager_unofficial
+++ b/probemanager_unofficial
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install or update probe scripts
-# Version 0.46 (20170515)
+# Version 0.47 (20170713)
 probeurl=http://project-mayhem.se/files/chprobe_latest_$(hostname -d).tgz
 probedefaults=http://project-mayhem.se/files/chprobe_latest_general.tgz
 probedir=/home/chprobe
@@ -43,7 +43,7 @@ case "$1" in
   echo '
 # CHPROBE SSH
 Port 34521' >> /etc/ssh/sshd_config
-echo "We're done"
+echo "We're done" && exit 0
     ;;
   update)
 #  echo 'Updating Manager'
@@ -73,20 +73,40 @@ echo "We're done"
   iptables -F;/bin/bash /root/fw-rules
   curl -s $managerurl -O $probedir/;sleep 1 && 
 chmod +x $probedir/probemanager
-# Temporary space #
+### Temporary space ###
+
+# Set some global vars
+export iperf3tcp_log="/var/log/iperf3tcp.log"
+export iperf3udp_log="/var/log/iperf3udp.log"
+# Enable strict mode permanently
+# echo "export strict_mode=true" >> /etc/profile.d/chprobe_settings.sh
+
+## Remove probemanager from git repo
   rm $probedir/probemanager_unofficial > /dev/null
-#  rm $probedir/tcp_iperf3_client_reversed-logstash.sh
-#  rm $probedir/tcp_iperf3_client-logstash.sh
+#  rm $probedir/chprobe_latest_*.tgz
+## Install motd and fix permissions for it
+  chown -R chprobe:chprobe /var/log/chprobe*
+  chown -R chprobe:chprobe /var/log/iperf*
+  curl http://project-mayhem.se/probes/chprobe_motd.sh -o /etc/profile.d/chprobe.sh
+  head -n 1 /home/chprobe/version-* | grep -oP '"\K[^"\047]+(?=["\047])' > /etc/chprobe_version
+
+## Alias for debugging collisions
+echo "clear && echo '### START ###' && { journalctl -n 50000 | egrep 'iperf3|bbk' | egrep 'Finished|Starting'; tail -n 200 /var/log/chprobe_bbk.log; tail -n 200 /var/log/iperf3tcp.log; } | sort && echo '### END ###'" > /usr/local/sbin/chprobe_collisiondebug && chmod +x /usr/local/sbin/chprobe_collisiondebug
+
+##  Create backupdir
 #  mkdir /root/backups
+
+## Install new filebeat config
 #  mv $probedir/filebeat.yml /etc/filebeat/filebeat.yml
 #  systemctl restart filebeat
+
+##  Install wrk binary (chprobe version)
 #  wget --no-cache http://project-mayhem.se/files/wrk_binary-x86.tgz -P /root/ &&
 #  tar xvfz /root/wrk_binary-x86.tgz -C /usr/bin/
-#  yum -y install http://project-mayhem.se/files/echoping.rpm
-#  yum -y install bind-utils &&
 #  rm -Rf /root/wrk_binary-x86.tgz*
-# Temporary space #
-  echo "We're done"
+
+### Temporary space ###
+  echo "We're done" && exit 0
     ;;
   restoredefault)
   echo 'Updating Manager'
@@ -123,13 +143,13 @@ chmod +x $probedir/probemanager
   echo 'Updating Manager'
   rm -f $probedir/probemanager; sleep 1 && wget --no-cache $managerurl -P $probedir/ && sleep 1 &&
  chmod +x $probedir/probemanager
-  echo "We're done"
+  echo "We're done" && exit 0
     ;;
   managerupdate)
   echo 'Updating Manager'
   pushd $probedir/
   curl -s $managerurl -O $probedir/;sleep 1 &&
- chmod +x $probedir/probemanager
+ chmod +x $probedir/probemanager && exit 0
     ;;
   *)
     echo "Usage: $0 {installation|update|restoredefault|managerupdate}" >&2

--- a/smokeslave_fakepost
+++ b/smokeslave_fakepost
@@ -20,7 +20,7 @@ else
 probedir=/home/chprobe
 curl -s http://project-mayhem.se --data-ascii DATA -A $(hostname -d) > /dev/null
 curl -s http://project-mayhem.se --data-ascii DATA -A smokeping-slave > /dev/null
-curl -s http://88.198.46.60 | grep Your | awk '{print $4}' | tr -d '</b>' | sed -e "s/^/$(date "+%b %d %H:%M:%S") $(hostname -d) chprobe_wanip[$(echo 9000]): $(cd $probedir && ls version-* | tr -d version-) /" | tr -s ' ' >> /var/log/chprobe_wanip.txt
+curl -s http://88.198.46.60 | grep Your | awk '{print $4}' | tr -d '</b>' | sed -e "s/^/$(date "+%b %d %H:%M:%S") $(hostname -d) chprobe_wanip[$(echo 9000]): $(cd $probedir && ls version-* | sed 's/\<version\>//g') /" | tr -s ' ' | tr -d '-' >> /var/log/chprobe_wanip.txt
 
 # Old filebeat report (without version)
 # curl -s http://88.198.46.60 | grep Your | awk '{print $4}' | tr -d '</b>' | sed -e "s/^/$(date "+%b %d %H:%M:%S") $(hostname -d) chprobe_wanip[$(echo 9000]): /" >> /var/log/chprobe_wanip.txt

--- a/version-0.96.18_beta
+++ b/version-0.96.18_beta
@@ -1,5 +1,7 @@
+current_version="0.96.18_beta"
+
 # Known issues
-# Last update: v.0.96.17
+# Last update: v.0.96.18
 1. Multiple iperf3 tests wating for a busy server will fail sometimes when exiting the loop, due to that the server might become busy during this short interval
 2. The contention loops in BBK/iperf3 are also effected by a busy iperf3 server. There should different cases for when the server is busy and when the iperf3 is actually running the test.
 
@@ -87,3 +89,9 @@
 1. Reverted udp daemons (#5 in previous v.0.96.16) due to server bandwitdh issues
 2. udp tests with 5m and 10m bitrates are no longer effected by anti-collisions mechanisms
 3. Improved remote zone mechanisms (bbk and iperf3tcp scripts)
+
+# v.0.96.18
+1. Minor fixes to bbk/iperf3tcp scripts
+2. Introduced busyfail loop to iperf3 scripts to fix the issue where tests are sometimes "skipped" due to a heavy loaded server
+3. Fixed problem with iperf3 not running when remote mgmt/zone server is down
+4. Added optional feature "strict mode" for icmp/multi-tests to reduce overhead and response times at the cost of doing slightly less tests


### PR DESCRIPTION
# v.0.96.18
1. Minor fixes to bbk/iperf3tcp scripts
2. Introduced busyfail loop to iperf3 scripts to fix the issue where tests are sometimes "skipped" due to a heavy loaded server
3. Fixed problem with iperf3 not running when remote mgmt/zone server is down
4. Added optional feature "strict mode" for icmp/multi-tests to reduce overhead and response times at the cost of doing slightly less tests